### PR TITLE
Patch 2

### DIFF
--- a/internal_HEAD.txt
+++ b/internal_HEAD.txt
@@ -1,1 +1,1 @@
-internal repo HEAD: 2197bbb77688b05a30a2cb08d314911f600524fe
+internal repo HEAD: 2577c2bc7d4ca18aaaa0b0766038b509382c6840

--- a/smoggnd.pro
+++ b/smoggnd.pro
@@ -42,7 +42,7 @@ win32 {
 }
 
 # Windows icon
-RC_FILE = "icon/smoggnd.rc"
+RC_ICONS = "icon/smoggnd.ico"
 
 linux {
     CONFIG += link_pkgconfig

--- a/smoggnd.pro
+++ b/smoggnd.pro
@@ -99,6 +99,9 @@ HEADERS += \
     source/predict/predicterworker.h \
     source/predict/predictmod.h \
     source/radios/ft817radio.h \
+    source/radios/ft847radio.h \
+    source/radios/ft991radio.h \
+    source/radios/icomradio.h \
     source/radios/radio.h \
     source/radios/smogradio.h \
     source/radios/ts2000radio.h \
@@ -166,6 +169,9 @@ SOURCES += \
     source/predict/predicterworker.cpp \
     source/predict/predictmod.cpp \
     source/radios/ft817radio.cpp \
+    source/radios/ft847radio.cpp \
+    source/radios/ft991radio.cpp \
+    source/radios/icomradio.cpp \
     source/radios/radio.cpp \
     source/radios/smogradio.cpp \
     source/radios/ts2000radio.cpp \

--- a/smoggnd.pro
+++ b/smoggnd.pro
@@ -2,8 +2,8 @@ TEMPLATE = app
 
 QT += qml quick widgets multimedia network serialport charts quickcontrols2
 
-lessThan(QT_MAJOR_VERSION, 5) | lessThan(QT_MINOR_VERSION, 12) {
-    error("Qt 5.12 is the minimum required version.")
+lessThan(QT_MAJOR_VERSION, 5) | lessThan(QT_MINOR_VERSION, 12) | lessThan(QT_PATCH_VERSION, 6) {
+    error("Qt 5.12.6 is the minimum required version.")
 }
 
 CONFIG += c++11 resources_big \

--- a/source/connection/uploadworker.cpp
+++ b/source/connection/uploadworker.cpp
@@ -29,7 +29,7 @@ UploadWorker::UploadWorker(const QUrl &serverAPIUrl,
     remaining_priv = 0;
     errorsInARow_priv = 0;
     pjw_priv.reset(new PacketsJSONWrapper());
-    QTimer::singleShot(0, [&] { loadUnsentPakcets(); });
+    QTimer::singleShot(0, [&] { loadUnsentPackets(); });
     uploadingTimeoutTimer_priv.setSingleShot(true);
     loginTimeoutTimer_priv.setSingleShot(true);
     QObject::connect(&upload_mgr_priv, &QNetworkAccessManager::finished, [&](QNetworkReply *reply) {
@@ -184,7 +184,7 @@ void UploadWorker::setRandomPrefix() {
     this->prefix = randomString;
 }
 
-void UploadWorker::loadUnsentPakcets() {
+void UploadWorker::loadUnsentPackets() {
     auto directory = QDir(uploadDirString);
     QStringList fileNameFilters = {"*" + this->fileNameEnding};
     auto fileNames = directory.entryList(fileNameFilters, QDir::Files | QDir::Readable | QDir::Writable);

--- a/source/connection/uploadworker.h
+++ b/source/connection/uploadworker.h
@@ -43,7 +43,7 @@ private:
     QScopedPointer<PacketsJSONWrapper> pjw_priv;
 
     void setRandomPrefix();
-    void loadUnsentPakcets();
+    void loadUnsentPackets();
     void setIsCurrentlyUploading(bool newValue);
     void setIsCurrentlyLoggingIn(bool newValue);
     void setIsLoggedIn(bool newValue);

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -9,6 +9,9 @@
 #include "source/packet/spectrumreceiver.h"
 #include "source/predict/predictercontroller.h"
 #include "source/radios/ft817radio.h"
+#include "source/radios/ft847radio.h"
+#include "source/radios/ft991radio.h"
+#include "source/radios/icomradio.h"
 #include "source/radios/smogradio.h"
 #include "source/radios/ts2000radio.h"
 #include "source/rotators/g5500rotator.h"
@@ -203,19 +206,27 @@ Q_DECL_EXPORT int main(int argc, char *argv[]) {
     engine.rootContext()->setContextProperty("sdrThread", sdrThread.data());
     engine.rootContext()->setContextProperty("messageProxy", &messageProxy);
 
-    UploadController uploadController(QUrl("https://gnd.bme.hu:8080/api/"),
-        uploadDirString,
-        "upload_queue.txt",
-        "rejected_packets.txt");
+    UploadController uploadController(
+        QUrl("https://gnd.bme.hu:8080/api/"), uploadDirString, "upload_queue.txt", "rejected_packets.txt");
     QObject::connect(&packetDecoder, &PacketDecoder::newPacketMinimal, &uploadController, &UploadController::newPacket);
     engine.rootContext()->setContextProperty("uploader", &uploadController);
 
     engine.rootContext()->setContextProperty("deviceDiscovery", &deviceDiscovery);
-    TS2000Radio ts2000(&predicterController);
-    engine.rootContext()->setContextProperty("ts2000", &ts2000);
     FT817Radio ft817(&predicterController);
     engine.rootContext()->setContextProperty("ft817", &ft817);
     QObject::connect(&satelliteChanger, &SatelliteChanger::newBaseFrequency, &ft817, &Radio::newBaseFrequency);
+    FT847Radio ft847(&predicterController);
+    engine.rootContext()->setContextProperty("ft847", &ft847);
+    QObject::connect(&satelliteChanger, &SatelliteChanger::newBaseFrequency, &ft847, &Radio::newBaseFrequency);
+    FT991Radio ft991(&predicterController);
+    engine.rootContext()->setContextProperty("ft991", &ft991);
+    QObject::connect(&satelliteChanger, &SatelliteChanger::newBaseFrequency, &ft991, &Radio::newBaseFrequency);
+    ICOMRadio icom(&predicterController);
+    engine.rootContext()->setContextProperty("icom", &icom);
+    QObject::connect(&satelliteChanger, &SatelliteChanger::newBaseFrequency, &icom, &Radio::newBaseFrequency);
+    TS2000Radio ts2000(&predicterController);
+    engine.rootContext()->setContextProperty("ts2000", &ts2000);
+    QObject::connect(&satelliteChanger, &SatelliteChanger::newBaseFrequency, &ts2000, &Radio::newBaseFrequency);
     SMOGRadio smogradio(&predicterController, &packetDecoder);
     engine.rootContext()->setContextProperty("smogradio", &smogradio);
     QObject::connect(&satelliteChanger, &SatelliteChanger::newBaseFrequency, &smogradio, &Radio::newBaseFrequency);

--- a/source/packet/spectrumreceiver.cpp
+++ b/source/packet/spectrumreceiver.cpp
@@ -219,7 +219,8 @@ void SpectrumReceiver::newSpectrumPacket(s1obc::SpectrumPacket spectrumPacket) {
         fillWithNoData();
         nextPacketCounter_priv++;
     }
-    for (uint i = 0; i < dataLength; i++) {
+    auto maxIndex = maxLengthPerPacket < dataLength ? maxLengthPerPacket : dataLength;
+    for (uint i = 0; i < maxIndex; i++) {
         series_priv->append(startFrequency_priv +
                                 nextPacketCounter_priv * (maxLengthPerPacket * measurementStepSize_priv) +
                                 i * measurementStepSize_priv,

--- a/source/qml/SettingsPage.qml
+++ b/source/qml/SettingsPage.qml
@@ -479,6 +479,7 @@ ScrollView {
                             model: sdrThread.sdrDevices
                             textRole: "display"
                             enabled: !sdrEnabledSwitch.checked
+                            currentIndex: sdrThread.sdrDevices.rowCount() > 0 ? 0 : -1
                         }
                         Button {
                             text: qsTr("Refresh devices")
@@ -857,6 +858,7 @@ ScrollView {
                     spacing: parent.spacing
 
                     Grid {
+                        enabled: !radioSwitch.checked && (radioCOMCombo.count > 0)
                         spacing: parent.spacing
                         columns: 2
                         verticalItemAlignment: Grid.AlignVCenter
@@ -997,7 +999,7 @@ ScrollView {
 
                 Switch{
                     id: rotatorSwitch
-                    enabled: (predicterController.tracking && rotatorCOMCombo.count > 0) || rotatorSwitch.checked
+                    enabled: (predicterController.tracking && rotatorCOMCombo.count > 0)
                     text: enabled? qsTr("Control an antenna rotator"): '<font color="red">Antenna rotator controlling is only allowed if tracking is running and a rotator is connected</font>'
                     checked: false
                     onCheckedChanged: {

--- a/source/qml/SettingsPage.qml
+++ b/source/qml/SettingsPage.qml
@@ -812,6 +812,15 @@ ScrollView {
                                 // smog radio
                                 smogradio.set5VOut(smogRadio5VOutSwitch.checked)
                                 smogradio.start(String(radioCOMCombo.currentText), 115200, radioOffsetSpinbox.value, true);
+                            } else if (radioModelCombo.currentIndex === 3) {
+                                //ft847
+                                ft847.start(String(radioCOMCombo.currentText), radioBaudRate.currentText, radioOffsetSpinbox.value);
+                            } else if (radioModelCombo.currentIndex === 4) {
+                                //ft991
+                                ft991.start(String(radioCOMCombo.currentText), radioBaudRate.currentText, radioOffsetSpinbox.value);
+                            } else if (radioModelCombo.currentIndex === 5) {
+                                //icom
+                                icom.start(String(radioCOMCombo.currentText), radioBaudRate.currentText, radioOffsetSpinbox.value);
                             }
                         } else {
                             // turning the radio off
@@ -824,6 +833,15 @@ ScrollView {
                             } else if (radioModelCombo.currentIndex === 2) {
                                 // smog radio
                                 smogradio.stop();
+                            } else if (radioModelCombo.currentIndex === 3) {
+                                // ft847 radio
+                                ft847.stop();
+                            } else if (radioModelCombo.currentIndex === 4) {
+                                // ft991 radio
+                                ft991.stop();
+                            } else if (radioModelCombo.currentIndex === 5) {
+                                // icom radio
+                                icom.stop();
                             }
                         }
                     }
@@ -849,7 +867,7 @@ ScrollView {
 
                         ComboBox {
                             id: radioModelCombo
-                            model: ['FT-817','TS-2000','SMOG']
+                            model: ['FT-817','TS-2000','SMOG','FT-847','FT-991','ICOM']
                             currentIndex: 0
                         }
 
@@ -880,7 +898,7 @@ ScrollView {
 
                         ComboBox {
                             id: radioBaudRate
-                            model: ['4800','9600']
+                            model: ['4800','9600','19200','38400']
                             visible: (radioModelCombo.currentIndex !== 2) // smogradio only supports 115200
                         }
 
@@ -928,16 +946,39 @@ ScrollView {
             }
 
             Connections {
-                target: ts2000
+                target: ft847
                 onSerialPortErrorSignal:{
                     serialErrorRadio.open();
                     logger.writeToLog("Radio error: An error has occurred during communcation through the COM port.");
                     radioSwitch.checked = false;
                 }
             }
-
+            Connections {
+                target: ft991
+                onSerialPortErrorSignal:{
+                    serialErrorRadio.open();
+                    logger.writeToLog("Radio error: An error has occurred during communcation through the COM port.");
+                    radioSwitch.checked = false;
+                }
+            }
+            Connections {
+                target: icom
+                onSerialPortErrorSignal:{
+                    serialErrorRadio.open();
+                    logger.writeToLog("Radio error: An error has occurred during communcation through the COM port.");
+                    radioSwitch.checked = false;
+                }
+            }
             Connections {
                 target: smogradio
+                onSerialPortErrorSignal:{
+                    serialErrorRadio.open();
+                    logger.writeToLog("Radio error: An error has occurred during communcation through the COM port.");
+                    radioSwitch.checked = false;
+                }
+            }
+            Connections {
+                target: ts2000
                 onSerialPortErrorSignal:{
                     serialErrorRadio.open();
                     logger.writeToLog("Radio error: An error has occurred during communcation through the COM port.");

--- a/source/qml/main.qml
+++ b/source/qml/main.qml
@@ -455,7 +455,9 @@ ApplicationWindow {
         standardButtons: Dialogs1.StandardButton.Ok
         text: qsTr("This program was created for the purpose of tracking and collecting telemetry from SMOG-1, SMOG-P and ATL-1."+
                    "\n\nIf you encounter any issues, please get in contact with us at bmegnd@gnd.bme.hu!"+
-                   "\n\nStay up to date through https://gnd.bme.hu/smog")
+                   "\n\nStay up to date through https://gnd.bme.hu/smog"+
+                   "\n\nThank you to our contributors:\n• OM3BC"+
+                   "\n\nVersion: 1.0.3")
     }
     Loader {
         id: manualPacketInputLoader

--- a/source/qml/subsystems/atl1/ObcSubsystem.qml
+++ b/source/qml/subsystems/atl1/ObcSubsystem.qml
@@ -41,7 +41,7 @@ Subsystem {
         TelemetryObject {
             group: "OBC"
             description: "EPS2-A T2"
-            value: telemetry3packet.obc.eps2PanelATemperature1_C10 / 10.0
+            value: telemetry3packet.obc.eps2PanelATemperature2_C10 / 10.0
             min: -40
             max: 80
             unit: "°C"

--- a/source/qml/subsystems/smog1/ObcSubsystem.qml
+++ b/source/qml/subsystems/smog1/ObcSubsystem.qml
@@ -57,7 +57,7 @@ Subsystem {
         TelemetryObject {
             group: "OBC"
             description: "EPS2-A T2"
-            value: telemetry3packet.obc.eps2PanelATemperature1_C10 / 10.0
+            value: telemetry3packet.obc.eps2PanelATemperature2_C10 / 10.0
             min: -40
             max: 80
             unit: "°C"

--- a/source/qml/subsystems/smogp/ObcSubsystem.qml
+++ b/source/qml/subsystems/smogp/ObcSubsystem.qml
@@ -41,7 +41,7 @@ Subsystem {
         TelemetryObject {
             group: "OBC"
             description: "EPS2-A T2"
-            value: telemetry3packet.obc.eps2PanelATemperature1_C10 / 10.0
+            value: telemetry3packet.obc.eps2PanelATemperature2_C10 / 10.0
             min: -40
             max: 80
             unit: "°C"

--- a/source/radios/ft817radio.cpp
+++ b/source/radios/ft817radio.cpp
@@ -29,8 +29,14 @@ void FT817Radio::setPortSettingsBasedOnBaudRate(int baudRate) {
     if (baudRate == 4800) {
         portSettings_prot.BaudRate = QSerialPort::Baud4800;
     }
-    else {
+    else if (baudRate == 9600) {
         portSettings_prot.BaudRate = QSerialPort::Baud9600;
+    }
+    else if (baudRate == 19200) {
+        portSettings_prot.BaudRate = QSerialPort::Baud19200;
+    }
+    else {
+        portSettings_prot.BaudRate = QSerialPort::Baud38400;
     }
     portSettings_prot.FlowControl = QSerialPort::NoFlowControl;
     portSettings_prot.Parity = QSerialPort::NoParity;

--- a/source/radios/ft817radio.h
+++ b/source/radios/ft817radio.h
@@ -5,7 +5,6 @@
 #include <QString>
 
 class FT817Radio : public Radio {
-    Q_OBJECT
 public:
     FT817Radio(PredicterController *predicter);
 

--- a/source/radios/ft847radio.cpp
+++ b/source/radios/ft847radio.cpp
@@ -1,0 +1,69 @@
+#include "ft847radio.h"
+
+FT847Radio::FT847Radio(PredicterController *predicter) : Radio(predicter, 300) {
+    baseOffset_prot = -1500;
+}
+
+void FT847Radio::setPortSettingsBasedOnBaudRate(int baudRate) {
+    if (baudRate == 4800) {
+        portSettings_prot.BaudRate = QSerialPort::Baud4800;
+    }
+    else if (baudRate == 9600) {
+        portSettings_prot.BaudRate = QSerialPort::Baud9600;
+    }
+    else if (baudRate == 19200) {
+        portSettings_prot.BaudRate = QSerialPort::Baud19200;
+    }
+    else {
+        portSettings_prot.BaudRate = QSerialPort::Baud38400;
+    }
+    portSettings_prot.FlowControl = QSerialPort::NoFlowControl;
+    portSettings_prot.Parity = QSerialPort::NoParity;
+    portSettings_prot.StopBits = QSerialPort::TwoStop;
+}
+
+/**
+ * @brief Sets mode and other settings for the radio.
+ */
+void FT847Radio::initialization() {
+    QByteArray temp; // set MODE to DIGI
+    temp.append(static_cast<char>(0x0A));
+    temp.append(static_cast<char>(0x00));
+    temp.append(static_cast<char>(0x00));
+    temp.append(static_cast<char>(0x00));
+    temp.append(0x07);
+    emit newCommand(temp);
+}
+
+/**
+ * @brief Sets frequency to \p frequencyHz.
+ * @param frequencyHz The new freuqncy as Hz
+ */
+void FT847Radio::setFrequency(unsigned long frequencyHz) {
+    if (frequencyHz >= 500000000) {
+        qWarning() << "Invalid frequency, it should be less than 500 MHz";
+        return;
+    }
+
+    QByteArray temp;
+    unsigned long truncated = frequencyHz / 10;
+    unsigned char fourth = static_cast<unsigned char>(truncated % 100);
+    truncated /= 100;
+    unsigned char third = static_cast<unsigned char>(truncated % 100);
+    truncated /= 100;
+    unsigned char second = static_cast<unsigned char>(truncated % 100);
+    truncated /= 100;
+    unsigned char first = static_cast<unsigned char>(truncated % 100);
+    temp.append((first / 10) * 16 + (first % 10));
+    temp.append((second / 10) * 16 + (second % 10));
+    temp.append((third / 10) * 16 + (third % 10));
+    temp.append((fourth / 10) * 16 + (fourth % 10));
+    temp.append(static_cast<char>(0x01));
+    emit newCommand(temp);
+}
+
+void FT847Radio::turnOn() {
+}
+
+void FT847Radio::turnOff() {
+}

--- a/source/radios/ft847radio.h
+++ b/source/radios/ft847radio.h
@@ -1,0 +1,19 @@
+#ifndef FT847RADIONEW_H
+#define FT847RADIONEW_H
+
+#include "radio.h"
+#include <QString>
+
+class FT847Radio : public Radio {
+public:
+    FT847Radio(PredicterController *predicter);
+
+protected:
+    void setPortSettingsBasedOnBaudRate(int baudRate) override;
+    void initialization() override;
+    void setFrequency(unsigned long frequencyHz) override;
+    void turnOff() override;
+    void turnOn() override;
+};
+
+#endif // FT847RADIO_H

--- a/source/radios/ft991radio.cpp
+++ b/source/radios/ft991radio.cpp
@@ -1,10 +1,10 @@
-#include "ts2000radio.h"
+#include "ft991radio.h"
 
-TS2000Radio::TS2000Radio(PredicterController *predicter) : Radio(predicter, 125) {
+FT991Radio::FT991Radio(PredicterController *predicter) : Radio(predicter, 125) {
     baseOffset_prot = -1500;
 }
 
-void TS2000Radio::setPortSettingsBasedOnBaudRate(int baudRate) {
+void FT991Radio::setPortSettingsBasedOnBaudRate(int baudRate) {
     if (baudRate == 4800) {
         portSettings_prot.BaudRate = QSerialPort::Baud4800;
     }
@@ -17,7 +17,7 @@ void TS2000Radio::setPortSettingsBasedOnBaudRate(int baudRate) {
     else {
         portSettings_prot.BaudRate = QSerialPort::Baud38400;
     }
-    portSettings_prot.FlowControl = QSerialPort::HardwareControl;
+    portSettings_prot.FlowControl = QSerialPort::NoFlowControl;
     portSettings_prot.Parity = QSerialPort::NoParity;
     if (portSettings_prot.BaudRate == QSerialPort::Baud4800) {
         portSettings_prot.StopBits = QSerialPort::TwoStop;
@@ -28,29 +28,29 @@ void TS2000Radio::setPortSettingsBasedOnBaudRate(int baudRate) {
 }
 
 /**
- * @brief TS2000 requires no additional operations during starting up
+ * @brief FT991 requires no additional operations during starting up
  */
-void TS2000Radio::initialization() {
-    emit newCommand(QString("MD2;").toLocal8Bit()); // Based on om3bc's input
+void FT991Radio::initialization() {
+    emit newCommand(QString("MD02;").toLocal8Bit()); // set MODE to USB
+    emit newCommand(QString("RC;").toLocal8Bit());   // clear CLAR
 }
 
 /**
  * @brief Sets VFO-A frequency to \p frequencyHz
  * @param frequencyHz Frequency as Hz
  */
-void TS2000Radio::setFrequency(unsigned long frequencyHz) {
-    emit newCommand(QString("FA%1;").arg(frequencyHz, 11, 10, QChar('0')).toLocal8Bit());
+void FT991Radio::setFrequency(unsigned long frequencyHz) {
+    emit newCommand(QString("FA%1;").arg(frequencyHz, 9, 10, QChar('0')).toLocal8Bit());
 }
 
 /**
  * @brief Does not turn the radio off, since there is no way to turn it back on.
  */
-void TS2000Radio::turnOff() {
-    // emit newCommand(QString("PS0;").toLocal8Bit());
+void FT991Radio::turnOff() {
 }
 
 /**
  * @brief There is no way to turn the radio on, so does nothing.
  */
-void TS2000Radio::turnOn() {
+void FT991Radio::turnOn() {
 }

--- a/source/radios/ft991radio.h
+++ b/source/radios/ft991radio.h
@@ -1,0 +1,19 @@
+#ifndef FT991RADIONEW_H
+#define FT991RADIONEW_H
+
+#include "radio.h"
+#include <QString>
+
+class FT991Radio : public Radio {
+public:
+    FT991Radio(PredicterController *predicter);
+
+protected:
+    void setPortSettingsBasedOnBaudRate(int baudRate) override;
+    void initialization() override;
+    void setFrequency(unsigned long frequencyHz) override;
+    void turnOff() override;
+    void turnOn() override;
+};
+
+#endif // FT991RADIO_H

--- a/source/radios/icomradio.cpp
+++ b/source/radios/icomradio.cpp
@@ -1,0 +1,74 @@
+#include "icomradio.h"
+
+ICOMRadio::ICOMRadio(PredicterController *predicter) : Radio(predicter, 300) {
+    baseOffset_prot = -1500;
+}
+
+void ICOMRadio::setPortSettingsBasedOnBaudRate(int baudRate) {
+    if (baudRate == 4800) {
+        portSettings_prot.BaudRate = QSerialPort::Baud4800;
+    }
+    else if (baudRate == 9600) {
+        portSettings_prot.BaudRate = QSerialPort::Baud9600;
+    }
+    else if (baudRate == 19200) {
+        portSettings_prot.BaudRate = QSerialPort::Baud19200;
+    }
+    else {
+        portSettings_prot.BaudRate = QSerialPort::Baud38400;
+    }
+    portSettings_prot.FlowControl = QSerialPort::NoFlowControl;
+    portSettings_prot.Parity = QSerialPort::NoParity;
+    portSettings_prot.StopBits = QSerialPort::OneStop;
+}
+
+/**
+ * @brief Sets mode and other settings for the radio.
+ */
+void ICOMRadio::initialization() {
+    QByteArray temp; // set MODE to USB
+    temp.append(static_cast<char>(0xFE));
+    temp.append(static_cast<char>(0xFE));
+    temp.append(static_cast<char>(0x00));
+    temp.append(static_cast<char>(0xE0));
+    temp.append(0x06);
+    temp.append(0x01);
+    temp.append(static_cast<char>(0xFD));
+    emit newCommand(temp);
+}
+
+/**
+ * @brief Sets frequency to \p frequencyHz.
+ * @param frequencyHz The new freuqncy as Hz
+ */
+void ICOMRadio::setFrequency(unsigned long frequencyHz) {
+    QByteArray temp;
+    unsigned long truncated = frequencyHz;
+    unsigned char fifth = static_cast<unsigned char>(truncated % 100);
+    truncated /= 100;
+    unsigned char fourth = static_cast<unsigned char>(truncated % 100);
+    truncated /= 100;
+    unsigned char third = static_cast<unsigned char>(truncated % 100);
+    truncated /= 100;
+    unsigned char second = static_cast<unsigned char>(truncated % 100);
+    truncated /= 100;
+    unsigned char first = static_cast<unsigned char>(truncated % 100);
+    temp.append(static_cast<char>(0xFE));
+    temp.append(static_cast<char>(0xFE));
+    temp.append(static_cast<char>(0x00));
+    temp.append(static_cast<char>(0xE0));
+    temp.append(0x05);
+    temp.append((first / 10) * 16 + (first % 10));
+    temp.append((second / 10) * 16 + (second % 10));
+    temp.append((third / 10) * 16 + (third % 10));
+    temp.append((fourth / 10) * 16 + (fourth % 10));
+    temp.append((fifth / 10) * 16 + (fifth % 10));
+    temp.append(static_cast<char>(0xFD));
+    emit newCommand(temp);
+}
+
+void ICOMRadio::turnOn() {
+}
+
+void ICOMRadio::turnOff() {
+}

--- a/source/radios/icomradio.h
+++ b/source/radios/icomradio.h
@@ -1,0 +1,19 @@
+#ifndef ICOMRADIONEW_H
+#define ICOMRADIONEW_H
+
+#include "radio.h"
+#include <QString>
+
+class ICOMRadio : public Radio {
+public:
+    ICOMRadio(PredicterController *predicter);
+
+protected:
+    void setPortSettingsBasedOnBaudRate(int baudRate) override;
+    void initialization() override;
+    void setFrequency(unsigned long frequencyHz) override;
+    void turnOff() override;
+    void turnOn() override;
+};
+
+#endif // ICOMRADIO_H

--- a/source/rotators/g5500rotator.cpp
+++ b/source/rotators/g5500rotator.cpp
@@ -5,7 +5,7 @@ G5500Rotator::G5500Rotator(PredicterController *predicter) : Rotator(predicter, 
 
 void G5500Rotator::setAZEL(unsigned int azimuth, unsigned int elevation) {
     emit newCommand(
-        QString("W%1 %2\n").arg(azimuth, 3, 10, QChar('0')).arg(elevation, 3, 10, QChar('0')).toLocal8Bit());
+        QString("W%1 %2\r\n").arg(azimuth, 3, 10, QChar('0')).arg(elevation, 3, 10, QChar('0')).toLocal8Bit());
 }
 
 void G5500Rotator::setPortSettingsBasedOnBaudRate(int baudRate) {

--- a/source/rotators/rotator.h
+++ b/source/rotators/rotator.h
@@ -35,6 +35,7 @@ protected:
     bool passCrossesStopPoint_prot = false; //!< True if the next pass crosses \p stoppingPositionAz_prot
     bool isCurrentlyFollowing_prot = false; //!< True if the rotator is following the satellite ATM
     int lastElevation_prot = -181;          //!< Previous elevation received from predicter
+    int lastAzimuth_prot = -361;            //!< Previous azimuth received from predicter
 
     bool isRunning() const;
     void setIsRunning(bool newValue);

--- a/source/utilities/serialporthandler.cpp
+++ b/source/utilities/serialporthandler.cpp
@@ -62,6 +62,10 @@ QSerialPort::SerialPortError SerialPortHandler::initPort(QString portName, const
         else {
             port_priv.open(QSerialPort::WriteOnly);
         }
+        if (settings.FlowControl != QSerialPort::HardwareControl) {
+            port_priv.setRequestToSend(false);
+            port_priv.setDataTerminalReady(false);
+        }
     }
     else {
         return QSerialPort::DeviceNotFoundError;


### PR DESCRIPTION
Changes:
- Multiple improvements from **om3bc** #11: 3 new radios, increased baud rates, rotator improvements, windows icon fix, misc. UI/UX improvements
- RTS and DTR is set to 0 unless hardware flow control is set (i.e. TS2000) - a popular request
- Revert a previous G5500 commit, fixes #10 
- Update about dialog, fixes #9
- 5.12.6 is now required to ensure [QTBUG-78086](https://bugreports.qt.io/browse/QTBUG-78086) is fixed (which affected serial port usage on Windows negatively). This may fix #2 as well
- Ensure spectrum data is not indexed out of range (even if the packet is corrupted and contains enormous data length), fixes #8 
- Misc. fixes
